### PR TITLE
Install ulmo from GitHub to avoid pandas.tslib error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,15 @@ COPY environment.yml environment.yml
 
 RUN conda env update -n root -f environment.yml
 
+RUN pip install git+https://github.com/ulmo-dev/ulmo.git
+
 RUN python -c "import rasterio"
 
 RUN python -c "from osgeo import gdal"
 
 RUN python -c "import geopandas"
+
+RUN python -c "import ulmo"
 
 RUN conda info --envs
 

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
   - gdal
   - libgdal
   - geojson
-  - ulmo
   - pyhdf
 
   # Jupyter Environment


### PR DESCRIPTION
This PR installs ulmo from GitHub, because the version on conda-forge relies on the `pandas.tslib` module that was deprecated then removed from pandas. 

It also tests the import in the Dockerfile so that the automated build checks to ensure that the package can be imported. This should fix the issue you discovered @EllenConsidine @ginaliqili 